### PR TITLE
LED Prioritize Yellow Over Red

### DIFF
--- a/sensors_script/device_availability_monitor.py
+++ b/sensors_script/device_availability_monitor.py
@@ -58,14 +58,14 @@ try:
     while True:
         log_data = get_log_tail() 
         
-        if is_installation_failed(log_data):
-            GPIO.output(GREEN_LED, GPIO.LOW)
-            GPIO.output(YELLOW_LED, GPIO.LOW)
-            GPIO.output(RED_LED, GPIO.HIGH)
-        elif is_package_installing():
+       	if is_package_installing():
             GPIO.output(GREEN_LED, GPIO.LOW)
             GPIO.output(RED_LED, GPIO.LOW)
             GPIO.output(YELLOW_LED, GPIO.HIGH)
+        elif is_installation_failed(log_data):
+            GPIO.output(GREEN_LED, GPIO.LOW)
+            GPIO.output(YELLOW_LED, GPIO.LOW)
+            GPIO.output(RED_LED, GPIO.HIGH)
         elif is_installation_success(log_data):
             set_green_default()
         else:


### PR DESCRIPTION
- Fixed issue where if QC machine is updated when detecting wrong color (Red LED is on) and is updated, yellow LED does not turn on.